### PR TITLE
!define command re-written from scratch

### DIFF
--- a/commands/define.js
+++ b/commands/define.js
@@ -1,212 +1,237 @@
 /**
- * author: ap4gh(Github) aka. debjay(on CodeCareer Discord Server)
- * command_name: define
- * version: 2.3
- * description: Search for passed text on wikipedia or ddg.
- * npm_dependencies: { request }
- */
-
-const request = require('request');
-// This func will return a formatted URL to get instant answer data from ddg in JSON format
-
-/**
- * Notify about errors to the maintainer and end-user.
- * This func takes the command used and error thrown
- * when the command fails. It notify maintainer via
- * direct message, change maintainer ID in the vari-
- * able below.
+ * author: ap4gh(Github), debjay(on CodeCareer Discord Server)
+ * license: MIT https://opensource.org/licenses/MIT
  */
 const maintainerID = '274434863711518722';
-const notifyErrors = (message, commandUsed, err = '') => {
-  message.channel.send('Some internal error occured!');
-  const author = message.guild.member(maintainerID);
-  author.send(`Error in command ${commandUsed}`);
-  author.send('```' + err + '```');
-};
+/**
+ * command_name: define
+ * version: 3.0
+ * description: Provides definition for words from web.
+ * npm_dependencies: { request, request-promise-native }
+ */
 
-const generateQueryURL = (serve, phrase) => {
+const request = require('request-promise-native');
+
+const maxRelatedTopics = 3;
+
+/*
+    ------------ HELPER FUNCTIONS ------------
+*/
+
+/**
+ * @name notifyErrors
+ * @description Notify maintainer and the end-user about the error.
+ * @param {Object.Prototype} message discord message object
+ * @param {Error} err error message
+ */
+const notifyErrors = (message, err = '') => {
+  // maintainer can be changed by changing the maintainer ID
+  // from the top of the file.
+  const author = message.guild.member(maintainerID);
+  author.send(`Message ID: ${message.id}`);
+  author.send('```' + err + '```');
+  message.channel.send(
+    `Some internal error occured, maintainer ${author} has been notified.`
+  );
+};
+/**
+ * @name sendMessage
+ * @description checks for errors and sends message to the channel.
+ * @param {Object.Prototype} message discord message object
+ * @param {String} messageContent text, embed, image path etc.
+ */
+const sendMessage = (message, messageContent) => {
+  try {
+    message.channel.send(messageContent);
+  } catch (e) {
+    console.error(e);
+    return notifyErrors(message, e);
+  }
+};
+/**
+ * @name generateQueryURL
+ * @description generate api query URL for service.
+ * @param {String} serve The service to look for definition wiki, ddg etc.
+ * @param {String} phrase search phrase entered by end-user.
+ */
+const generateQueryURL = (phrase, service = 'ddg') => {
   const queryURLs = {
     wiki: `https://en.wikipedia.org/w/api.php?action=opensearch&list=search&search=${phrase}&format=json&formatversion=2`,
     ddg: `https://api.duckduckgo.com/?q=${phrase}&format=json`
   };
-  return queryURLs[serve];
+  return encodeURI(queryURLs[service]);
+};
+/**
+ * @name runCommand
+ * @description screen command and return the function running that command.
+ * @param {Object.Prototype} message discord message object
+ * @param {Array.Prototype} args arguments passed with the command
+ * @param {String} commandName name of command
+ */
+const runUserCommand = (message, args, commandName = '') => {
+  const availableCommands = {
+    '-h': showHelp,
+    '--help': showHelp,
+    wiki: wikipediaOpenSearch,
+    default: ddgInstantAnswer
+  };
+  // if commandName does not match any, return default
+  return (availableCommands[commandName] || availableCommands.default)(
+    message,
+    args
+  );
 };
 
+/*
+    ------------ COMMAND FUNCTIONS ------------
+*/
+
+/**
+ *      •• DUCKDUCKGO INSTANT ANSWER ••
+ */
+const ddgInstantAnswer = async (message, args) => {
+  // join args to create a search phrase
+  const searchPhrase = args.slice(0, args.length).join(' ');
+  let data;
+  try {
+    data = await request({
+      url: generateQueryURL(searchPhrase),
+      json: true,
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
+  } catch (e) {
+    console.error(e);
+    // if request fails report errors
+    return notifyErrors(message, e);
+  }
+  let result = `:mag: \`${searchPhrase}\`\n`;
+  const relatedTopics = data['RelatedTopics'];
+  const abstractText = data['AbstractText'];
+  const abstractURL = data['AbstractURL'];
+  // if no data is provided:
+  if (relatedTopics.length === 0) {
+    result += `Cannot find information on *${searchPhrase}* :no_good: Read the command guide with \`!define --help\` to get accurate results.`;
+  } // if abstract data is missing:
+  else if (!abstractText || !abstractURL) {
+    result += `*"${searchPhrase}" may refer to following things*  :point_down:\n\n`;
+    for (let topic of relatedTopics) {
+      // keeping maximum of 3 related topics to be displayed.
+      // maximum related topics can be changed at the top.
+      // NOTE: discord do not allow a message length > 2000
+      // characters.
+      if (
+        topic['Text'] === undefined ||
+        topic['FirstURL'] === undefined ||
+        relatedTopics.indexOf(topic) >= maxRelatedTopics
+      )
+        break;
+      result += `${topic['Text']}\n${topic['FirstURL']}\n\n`;
+    }
+  } // if abstract data exist:
+  else {
+    result += '```' + abstractText + '```:link: ' + abstractURL;
+  }
+  return sendMessage(message, result);
+};
+
+/**
+ *      •• WIKIPEDIA OPEN SEARCH ••
+ */
+const wikipediaOpenSearch = async (message, args) => {
+  // join args after 'wiki' to create a search phrase
+  const searchPhrase = args.slice(1, args.length).join(' ');
+  let data;
+  try {
+    data = await request({
+      url: generateQueryURL(searchPhrase, 'wiki'),
+      json: true,
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
+  } catch (e) {
+    console.error(e);
+    return notifyErrors(message, e);
+  }
+  // all definitions:
+  const definitions = data[2];
+  // all wikipedia page links:
+  const links = data[3];
+  // main definition page link:
+  let wikipediaPageLink = ':link: ' + links[0];
+  let result = definitions[0];
+  // no information is received from wikipedia:
+  if (!result) {
+    result = `No information provided for *${searchPhrase}* :no_good: `;
+  } // a word have more than one meaning:
+  else if (result.match(/may refer to/g)) {
+    result =
+      `:mag: **Wikipedia**: \`${searchPhrase}\`\n\n` +
+      '```\n' +
+      result +
+      '\n\n';
+    // remove useless definition at index 0:
+    definitions.shift();
+    // collect related definition:
+    for (let d of definitions) {
+      result += `${definitions.indexOf(d) + 1}. ${d}\n\n`;
+      if (definitions.indexOf(d) === maxRelatedTopics - 1) break;
+    }
+    result += '```';
+  } // exact meaning is obtained:
+  else {
+    result =
+      `:mag: ${searchPhrase}` + '```' + result + '```' + wikipediaPageLink;
+  }
+  return sendMessage(message, result);
+};
+
+/**
+ *      •• HELP COMMAND ••
+ */
+const showHelp = (message, args) => {
+  message.channel.send(`
+    \`\`\`
+NAME
+  define -- provide definition for words from web.
+
+DESCRIPTION
+  !define command gets abstract information on a word from
+  duckduckgo and wikipedia.
+
+COMMANDS
+  1) !define <search-text>         DuckDuckGo instant answer.
+  2) !define wiki <search-text>    Wikipedia definition.
+  3) !define -h[--help]            Provides help text.
+
+EXAMPLES
+  > !define yellow stone
+  > !define wiki object oriented programming
+
+GUIDE
+  !define will only show definition on receiving exact info,
+  in case a word have more than one meaning, related topics
+  (not more than three) will be displayed. To get more acc-
+  urate results pass more keywords in search phrase sepearted  
+  with spaces. Eg: 'react' means many things but if you want 
+  to get definition for 'reactjs' use command like this:
+
+  > !define reactjs
+          OR
+  > !define wiki react javascript
+
+  For now, !define only provide information about things, places,
+  events, news etc. and does not provide meaning of the words from
+  english dictionary. DDG bang redirects will also not work here.
+    \`\`\` 
+    `);
+};
+
+// run function for !define command:
 exports.run = (client, message, args) => {
-  // if nothing was passed after typing the command name:
-  if (args.length === 0) {
-    return message.channel.send(
-      'Try `!define --help` to get list of available commands and usage examples.'
-    );
-  }
-  /**
-   * First argument can be a sub-command or word.
-   */
-  switch (args[0]) {
-    // MAIN COMMAND: define
-    default:
-      /**
-       * request takes two arguments, first is the option object,
-       * second is a callback function.
-       */
-      const searchPhrase = args.slice(0, args.length).join(' ');
-      request(
-        // Options
-        {
-          url: generateQueryURL('ddg', searchPhrase),
-          headers: {
-            'Content-Type': 'application/json'
-          }
-        },
-        // Callback function
-        (error, response, body) => {
-          // Only run when data is recieved with statusCode of 200
-          if (!error && response.statusCode == 200) {
-            // Parse JSON data
-            const data = JSON.parse(body);
-            // Abstract text
-            const abstractText = data['AbstractText'];
-            // If no abstractText is found then:
-            let msg = '';
-            if (!abstractText) {
-              msg = `Definition not provided :shrug: ${
-                data['RelatedTopics'].length > 0
-                  ? 'please check these following links or'
-                  : ''
-              } try \`!define wiki ${searchPhrase}\` for wikipedia results.\n\n`;
-              // maximum number of related topic info to be sent
-              let numOfRelatedTopics = 3;
-              data['RelatedTopics'].every((topic, index) => {
-                /**
-                 * For some related topics, no links are provided,
-                 * hence those are not collected and the loop is
-                 * exited.
-                 */
-                if (!topic['Text']) {
-                  return false;
-                } else {
-                  msg += `${topic['FirstURL']}\n*${topic['Text']}*\n\n`;
-                  numOfRelatedTopics -= 1;
-                  // if all the three topic info is collected, exit.
-                  if (numOfRelatedTopics === 0) return false;
-                  return true;
-                }
-              });
-            } else {
-              // If abstractText is found:
-              msg = `Definition for \`${searchPhrase}\` `;
-              msg += '```' + abstractText + '```';
-            }
-            try {
-              message.channel.send(msg);
-            } catch (e) {
-              // notify end-user and maintainer about the error.
-              notifyErrors(message, `!define ${searchPhrase}`, e);
-            }
-          } else {
-            console.log(`Response status code: ${response.statusCode}`);
-            console.log(error || 'No errors while fetching data!');
-            // notify end-user and maintainer about the error.
-            notifyErrors(message, `!define ${searchPhrase}`, error);
-          }
-        }
-      );
-      break;
-
-    /* SUB COMMAND: wiki
-     * description: This command does an open search for the text
-     * passed by the end-user on wikipedia. Then the most accurate
-     * definition and its wikipedia page link is sent in a nice
-     * format.
-     */
-    case 'wiki':
-      // search text to send to wikipedia:
-      const wikiSearchPhrase = args.slice(1, args.length).join(' ');
-      // request for JSON response data:
-      request(
-        {
-          url: generateQueryURL('wiki', wikiSearchPhrase),
-          headers: {
-            'Content-Type': 'application/json'
-          }
-        },
-        (error, response, body) => {
-          if (!error && response.statusCode === 200) {
-            // JSON parsed data is an array containing 4 elements:
-            const data = JSON.parse(body);
-            // extracted definition and links:
-            const definitions = data[2];
-            const links = data[3];
-            // wikipedia page link for main topic:
-            let wikipediaPageLink = ':link: ' + links[0];
-            // first definition provided by wikipedia:
-            let firstDefinition = definitions[0];
-            /**
-             * first definition may be empty, undefined or
-             * placeholder text. It should be checked before
-             * adding it to the main response.
-             */
-            // CASE 1: If firstDefinition is empty:
-            if (!firstDefinition) {
-              firstDefinition = '```No information provided.```';
-            } // CASE 2: If it is a placeholder text(inaccurate definition):
-            else if (firstDefinition.match(/may refer to/g)) {
-              firstDefinition = '```' + firstDefinition + '\n\n';
-              // no wikipedia page link if accurate definition is not provided.
-              wikipediaPageLink = '';
-              /**
-               * NOTE: Discord only allows a max. of 2000 words
-               * to be sent in one go. Hence, I have to shorten
-               * the message to send only 3 related topic info.
-               */
-              for (i = 1; i < 4; i++) {
-                firstDefinition += i + '. ' + definitions[i] + '\n\n';
-              }
-              firstDefinition += '```';
-            } // CASE 3: firstDefinition is provided:
-            else {
-              firstDefinition =
-                '```' + firstDefinition + '```' + wikipediaPageLink;
-            }
-            // creating a message format string:
-            let formattedMsg = ':mag: `' + wikiSearchPhrase + '`\n';
-            formattedMsg += firstDefinition;
-            // send message and try catch errors:
-            try {
-              message.channel.send(formattedMsg);
-            } catch (e) {
-              // notify end-user and maintainer about the error.
-              notifyErrors(message, `!define wiki ${wikiSearchPhrase}`, e);
-            }
-          } else {
-            // Report errors in log.
-            console.log(
-              `ERROR in requesting: Response status code: ${
-                response.statusCode
-              }`
-            );
-            console.log(error || 'No errors while fetching data!');
-            // notify end-user and maintainer about the error.
-            notifyErrors(message, `!define wiki ${wikiSearchPhrase}`, error);
-          }
-        }
-      );
-      break;
-    // !define --help or -h
-    case '-h':
-    case '--help':
-      message.channel.send(`
-        \`\`\`
-AVAILABLE COMMANDS
-
-    1. !define <search-text>         DuckDuckGo instant answer.
-    2. !define wiki <search-text>    Wikipedia definition.
-
-EXAMPLES:
-
-    !define yellow stone
-    !define wiki object oriented programming
-        \`\`\` `);
-      break;
-  }
+  if (args.length === 0)
+    message.channel.send('Try `!define --help` to get command guide.');
+  runUserCommand(message, args, args[0]);
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "private": true,
   "dependencies": {
     "discord.js": "^11.4.2",
-    "request": "^2.88.0"
+    "request": "^2.88.0",
+    "request-promise-native": "^1.0.7"
   }
 }


### PR DESCRIPTION
---
command: !define
about: re written from scratch
---
`!define` command is re written from scratch. It is done to improve structure of the command. Switch statement is removed. Help text is improved. It is now easy to add new sub commands without creating a case expression in bloated switch statement.

changes:
- switch case statement removed
- help text is updated
- api URI is now encoded so things like `!define 🍰` will work(although still not with wikipedia).
- notifyError works amazingly 🎉 
- better comments
- license and copyrights update