### PR TITLE
CORS Access-Control headers added in response.

### DIFF
--- a/utils/server.js
+++ b/utils/server.js
@@ -6,7 +6,15 @@ const Config = require('./config')
 class ApiServer {
     constructor() {
         this.server = http.createServer((req, res) => {
-            res.writeHead(200, {'Content-Type': 'application/json'})
+
+            let headers = {
+                'Content-Type': 'application/json',
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Methods': 'GET',
+                'Access-Control-Max-Age': 2592000,
+            }
+
+            res.writeHead(200, headers)
 
             let routes = this.getRoutes();
             let routePrefix = Config.getApiRoutePrefix()
@@ -22,9 +30,16 @@ class ApiServer {
     }
 
     handleResponse(res, route) {
-        let contentHeader = route.middleware.includes('web')
-                        ? {'Content-Type': 'text/html'}
-                        : {'Content-Type': 'application/json'};
+        let contentHeader = {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET',
+            'Access-Control-Max-Age': 2592000,
+        }
+
+        route.middleware.includes('web') ? 
+            contentHeader['Content-Type'] = 'text/html' :
+            contentHeader['Content-Type'] = 'application/json';
+
         res.writeHead(200, contentHeader)
         let body = route.middleware.includes('web')
             ? route.method().toString()
@@ -42,7 +57,7 @@ class ApiServer {
     }
 
     startListening() {
-        this.getServer().listen(Config.getServerPort(), function() {
+        this.getServer().listen(Config.getServerPort(), function () {
             console.log(
                 [`API web server started and listening on port `.yellow, `${Config.getServerPort()}`.magenta.bold].join('')
             )


### PR DESCRIPTION
Just adding `Access-Control` to response headers to enable CORS for *member-count* endpoint.